### PR TITLE
Use alpha shapes to plot invariant set to avoid artifacts due to nonconvexity

### DIFF
--- a/scripts/plot_invariant_set.m
+++ b/scripts/plot_invariant_set.m
@@ -44,7 +44,8 @@ function plot_invariant_set(controller)
     fig = figure(1);
     clf;
 
-    trisurf(k,points(:,1),points(:,2),points(:,3),'Facecolor','red')
+    plot(alphaShape(points(:,1),points(:,2),points(:,3), 4));
+    axis normal
     xlabel('Lateral velocity - v_y [m/s]', 'FontSize', scale*8)
     ylabel('Yaw rate - r [m/s]', 'FontSize', scale*8)
     zlabel('Longitudinal velocity - v_x [m/s]', 'FontSize', scale*8)


### PR DESCRIPTION


Issue: #43 Correct bug in invariant set plot, where it crops its corners